### PR TITLE
fix: make nav not show up in it's scrollable version in playground only

### DIFF
--- a/src/components/navigation/Navbar.tsx
+++ b/src/components/navigation/Navbar.tsx
@@ -80,7 +80,7 @@ export default function Navbar() {
 
     handleScroll();
 
-    window.addEventListener("scroll", handleScroll);
+    if (!window.location.href.includes("playground")) window.addEventListener("scroll", handleScroll);
 
     return () => {
       window.removeEventListener("scroll", handleScroll);


### PR DESCRIPTION
#134 
![image](https://github.com/user-attachments/assets/3df9afcf-11b0-475c-b33f-8aa7baa840e6)
